### PR TITLE
feature: implement boolean type

### DIFF
--- a/tiny/src/compiler.rs
+++ b/tiny/src/compiler.rs
@@ -41,6 +41,10 @@ impl Compiler {
                 self.code.push(OpCode::Push(TinyObject::Int(n)));
                 Ok(())
             }
+            Expr::Bool(b) => {
+                self.code.push(OpCode::Push(TinyObject::Bool(b)));
+                Ok(())
+            }
             Expr::BinOp(boxed_op) => self.compile_binop(*boxed_op),
             Expr::If { cond, thn, els } => self.compile_if(*cond, *thn, *els),
         }

--- a/tiny/src/parser.rs
+++ b/tiny/src/parser.rs
@@ -103,6 +103,7 @@ impl Parser {
     fn parse_primary_expr(&mut self) -> Result<Expr, ParseError> {
         match self.next() {
             Some(Token::LiteralInt(n)) => Ok(Expr::Int(*n)),
+            Some(Token::LiteralBool(b)) => Ok(Expr::Bool(*b)),
             Some(actual) => Err(ParseError::UnexpectedToken {
                 expected: None,
                 actual: actual.clone(),

--- a/tiny/src/tokenizer.rs
+++ b/tiny/src/tokenizer.rs
@@ -63,7 +63,7 @@ impl Tokenizer {
                     Self::tokenize_recursive(rest, tokens)
                 }
                 Err(e) => Err(e),
-            }
+            },
             c => Err(TokenizeError::UnexpectedCharacter(c)),
         }
     }

--- a/tiny/src/value_object/ast.rs
+++ b/tiny/src/value_object/ast.rs
@@ -11,6 +11,7 @@ pub enum Expr {
         els: Box<Expr>,
     },
     Int(i32),
+    Bool(bool),
     BinOp(Box<BinaryOperation>),
 }
 

--- a/tiny/src/value_object/tiny_object.rs
+++ b/tiny/src/value_object/tiny_object.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq)]
 pub enum TinyObject {
     Int(i32),
+    Bool(bool),
 }

--- a/tiny/src/value_object/token.rs
+++ b/tiny/src/value_object/token.rs
@@ -4,6 +4,7 @@ pub enum Token {
     KeywordPlus,
     KeywordQuestion,
     LiteralInt(i32),
+    LiteralBool(bool),
 }
 
 pub fn token_to_string(t: Token) -> String {
@@ -12,5 +13,6 @@ pub fn token_to_string(t: Token) -> String {
         Token::KeywordPlus => String::from("+"),
         Token::KeywordQuestion => String::from("?"),
         Token::LiteralInt(i) => format!("{}", i),
+        Token::LiteralBool(b) => format!("{}", b),
     }
 }

--- a/tiny/src/vm.rs
+++ b/tiny/src/vm.rs
@@ -5,6 +5,7 @@ use crate::value_object::tiny_object::TinyObject;
 pub enum RuntimeError {
     StackUnderflow,
     InvalidJump,
+    InvalidOperation,
 }
 
 pub fn runtime_error_to_message(e: RuntimeError) -> String {
@@ -13,6 +14,7 @@ pub fn runtime_error_to_message(e: RuntimeError) -> String {
             "stack underflow: not enough values on the stack".to_string()
         }
         RuntimeError::InvalidJump => "invalid jump: jump target is out of bounds".to_string(),
+        RuntimeError::InvalidOperation => "invalid operation: jump target is out of bounds".to_string(),
     }
 }
 
@@ -45,6 +47,7 @@ impl VM {
                         (TinyObject::Int(a), TinyObject::Int(b)) => {
                             self.stack.push(TinyObject::Int(a + b));
                         }
+                        _ => return Err(RuntimeError::InvalidOperation),
                     }
                     self.pc += 1;
                 }
@@ -78,8 +81,7 @@ impl VM {
     fn evaluate_condition(obj: TinyObject) -> bool {
         match obj {
             TinyObject::Int(n) => n > 0,
-            #[allow(unreachable_patterns)]
-            _ => false, // we use this in future
+            TinyObject::Bool(b) => b,
         }
     }
 }

--- a/tiny/src/vm.rs
+++ b/tiny/src/vm.rs
@@ -14,7 +14,9 @@ pub fn runtime_error_to_message(e: RuntimeError) -> String {
             "stack underflow: not enough values on the stack".to_string()
         }
         RuntimeError::InvalidJump => "invalid jump: jump target is out of bounds".to_string(),
-        RuntimeError::InvalidOperation => "invalid operation: jump target is out of bounds".to_string(),
+        RuntimeError::InvalidOperation => {
+            "invalid operation: jump target is out of bounds".to_string()
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces support for boolean literals (`true` and `false`) in the Tiny language, along with several related enhancements and bug fixes. The changes span the tokenizer, parser, compiler, and virtual machine (VM) to ensure proper handling of boolean values. Additionally, error handling has been improved for invalid operations.

### Boolean Support:

* **Tokenizer Enhancements**: Added a new function `parse_str_token` to recognize boolean literals (`true` and `false`) and report unexpected keywords as errors. Updated the tokenizer to handle ASCII characters and introduced the `UnexpectedKeyword` variant in `TokenizeError`. (`tiny/src/tokenizer.rs`: [[1]](diffhunk://#diff-2d07973a522e12c444f58b50b0258bc2ed64aaf98bdf4ae97aaef9ec34edf77eR7-R14) [[2]](diffhunk://#diff-2d07973a522e12c444f58b50b0258bc2ed64aaf98bdf4ae97aaef9ec34edf77eR60-R66) [[3]](diffhunk://#diff-2d07973a522e12c444f58b50b0258bc2ed64aaf98bdf4ae97aaef9ec34edf77eR90-R109)
* **Parser Updates**: Modified `parse_primary_expr` to parse `LiteralBool` tokens into `Expr::Bool`. (`tiny/src/parser.rs`: [tiny/src/parser.rsR106](diffhunk://#diff-6875d5ed36db547123260f36fefa928e9d67491f72e00315268ede685312faefR106))
* **Compiler Changes**: Updated the compiler to handle `Expr::Bool` by pushing `TinyObject::Bool` onto the code stack. (`tiny/src/compiler.rs`: [tiny/src/compiler.rsR44-R47](diffhunk://#diff-26ca56244fcf953bf57a866d2bf11b1ce108d4ac93eeee4de975d26364a3b22cR44-R47))
* **AST and Token Updates**: Added `Bool(bool)` to the `Expr` enum and `LiteralBool(bool)` to the `Token` enum. Updated `token_to_string` to support boolean literals. (`tiny/src/value_object/ast.rs`: [[1]](diffhunk://#diff-f40345112ca16f3de5a3eb1244eac05a5bad3301895ec19cf2d6392728ed113fR14) `tiny/src/value_object/token.rs`: [[2]](diffhunk://#diff-ee9c754a601bb3ff92aa0d23bef921471939ffdf93197b00cf8a8f48c535c26cR7) [[3]](diffhunk://#diff-ee9c754a601bb3ff92aa0d23bef921471939ffdf93197b00cf8a8f48c535c26cR16)
* **TinyObject Updates**: Introduced `Bool(bool)` to the `TinyObject` enum for VM representation. (`tiny/src/value_object/tiny_object.rs`: [tiny/src/value_object/tiny_object.rsR4](diffhunk://#diff-4ae43c833d1a9ed6a3e26fd7fb9a5a49e377206c09434881182c3a316e2b8386R4))

### Virtual Machine Enhancements:

* **Boolean Evaluation**: Updated `evaluate_condition` to handle `TinyObject::Bool` for conditional expressions. (`tiny/src/vm.rs`: [tiny/src/vm.rsL81-R84](diffhunk://#diff-bda1cf90322b81cee2586b9c47f6af648d0be3d56630cbac85ef3fb9f6c99c19L81-R84))
* **Error Handling**: Added `InvalidOperation` to `RuntimeError` and updated the VM to return this error for unsupported operations. (`tiny/src/vm.rs`: [[1]](diffhunk://#diff-bda1cf90322b81cee2586b9c47f6af648d0be3d56630cbac85ef3fb9f6c99c19R8) [[2]](diffhunk://#diff-bda1cf90322b81cee2586b9c47f6af648d0be3d56630cbac85ef3fb9f6c99c19R17) [[3]](diffhunk://#diff-bda1cf90322b81cee2586b9c47f6af648d0be3d56630cbac85ef3fb9f6c99c19R50)